### PR TITLE
[HOT FIX] Wrong submodule directory name. Simple fix, changed name in…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
 
   vertisim_service:
     build:
-      context: ./vertisim_dev
+      context: ./VertiSim
     ports:
       - "5001:5001"
     networks:
       - rl_network
     volumes:
-      - ./vertisim_dev:/app      
+      - ./VertiSim:/app      
 
   service_orchestrator:
     build:


### PR DESCRIPTION
Very "simple" error with wrong directory naming. Reference has been chagned in docker-compose.yml